### PR TITLE
refactor: remove access token refresh on client init

### DIFF
--- a/pyrevolut/client/base.py
+++ b/pyrevolut/client/base.py
@@ -679,10 +679,6 @@ class BaseClient:
         if self.credentials.credentials_expired:
             raise ValueError(f"Credentials are expired. {solution_msg}")
 
-        # Check if the access token is expired
-        if self.credentials.access_token_expired:
-            self.refresh_access_token()
-
     def save_credentials(self):
         """Save the credentials to the credentials file."""
         if self.custom_save_fn is not None:


### PR DESCRIPTION
To avoid having an immediate API call on client initialization. Access token refresh checks will occur on actual API calls made by user.